### PR TITLE
12 add new stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The remainder of the charts in the response can be produced from code in the rep
   - You can specify which batch of EPC data to download and MCS data to load from S3 by passing the `--epc_batch` and `--mcs_batch` arguments, both
     default to downloading/loading the newest data from S3, respectively.
   - You can specify which supplementary data folder to use by passing the `--supp_data` argument. It defaults to using the latest supplementary data folder.
+  - To recreate the full October 2023 analysis, set the `--calculate_average_installations` argument to `True`. This will calculate some additional numbers on MCS installations per year included in the October 2023 response. For other historical analyses, this argument is not required and defaults to `False`.
   - Run `python asf_welsh_energy_consultation/analysis/produce_plots_and_stats.py -h` for more info.
 
 The script should generate the following six plots which will be saved in your local repo in `outputs/figures`:
@@ -79,6 +80,7 @@ October 2023 analysis (`/inputs/data/data_202310`):
 - EPC: 2023_Q2_complete (preprocessed, and preprocessed and deduplicated)
 - mcs_installations_231009.csv
 - mcs_installations_epc_full_231009.csv
+- dwellings_2021.xlsx - [Number of dwellings by housing characteristics in England and Wales 2021 (released 30 March 2023)](https://www.ons.gov.uk/peoplepopulationandcommunity/housing/datasets/numberofdwellingsbyhousingcharacteristicsinenglandandwales)
 - off-gas-live-postcodes-2022.xlsx - check [here](https://www.xoserve.com/a-to-z/) for updates
 - postcodes - [ONS Postcode Directory (August 2023)](https://geoportal.statistics.gov.uk/datasets/ons-postcode-directory-august-2023/about)
 - postcode_to_output_area.csv - [postcode to OA, LSOA, MSAO, LAD lookup (May 2022)](https://geoportal.statistics.gov.uk/datasets/e7824b1475604212a2325cd373946235)
@@ -93,6 +95,7 @@ April 2023 analysis (`/inputs/data/data_202304`):
 - off-gas-live-postcodes-2022.xlsx - check [here](https://www.xoserve.com/a-to-z/) for updates
 - rurality.ods - 2011 Rural Urban Classification for small area geographies, see [here](https://www.ons.gov.uk/methodology/geography/geographicalproducts/ruralurbanclassifications)
 - postcodes ; postcode_to_output_area.csv ; tenure.csv - ONS data with unknown source date
+- dwellings data not historically used in this analysis
 
 ## Contributor guidelines
 

--- a/asf_welsh_energy_consultation/analysis/produce_plots_and_stats.py
+++ b/asf_welsh_energy_consultation/analysis/produce_plots_and_stats.py
@@ -9,7 +9,7 @@ import logging
 
 from asf_welsh_energy_consultation import config_file
 from asf_welsh_energy_consultation.config import translation_config
-from asf_welsh_energy_consultation.getters.get_data import get_electric_tenure
+from asf_welsh_energy_consultation.getters import get_data
 from asf_welsh_energy_consultation.pipeline import process_data
 from asf_welsh_energy_consultation.getters.get_data import load_wales_df, load_wales_hp
 from asf_welsh_energy_consultation.pipeline.plotting import (
@@ -162,7 +162,7 @@ if __name__ == "__main__":
     # ======================================================
     # Split of properties on electric heating by tenure
 
-    electric_tenure = get_electric_tenure()
+    electric_tenure = get_data.get_electric_tenure()
     N = electric_tenure["n"].sum()
 
     electric_tenure_chart = (
@@ -189,6 +189,7 @@ if __name__ == "__main__":
 
     wales_df = load_wales_df(from_csv=False)
     wales_hp = load_wales_hp(wales_df)
+    wales_mcs = process_data.get_enhanced_mcs()
 
     # English plots
 
@@ -217,7 +218,28 @@ if __name__ == "__main__":
     epc_c_wall_proportion = f"As a proportion of properties in EPC: {len(epc_c_or_above_and_good_walls) / len(wales_df)}\n"
 
     epc_c_wall_roof = f"\n\nNumber of EPC C+ properties with good or very good wall and roof insulation: {len(epc_c_or_above_and_good_walls_and_roof)}\n"
-    epc_c_wall_roof_proportion = f"As a proportion of properties in EPC: {len(epc_c_or_above_and_good_walls_and_roof) / len(wales_df)}"
+    epc_c_wall_roof_proportion = f"As a proportion of properties in EPC: {len(epc_c_or_above_and_good_walls_and_roof) / len(wales_df)}\n\n"
+
+    installations_by_rurality = (
+        "MCS installations by rurality\n"
+        + (
+            wales_mcs["rurality_2_label"].value_counts(normalize=True, dropna=False)
+            * 100
+        ).to_string()
+        + "\n\n"
+    )
+    installations_by_gas_status = (
+        "MCS installations by gas status\n"
+        + (
+            wales_mcs["off_gas"].value_counts(normalize=True, dropna=False) * 100
+        ).to_string()
+        + "\n\n"
+    )
+
+    percent_properties_by_rurality = str(
+        process_data.get_total_rural_and_urban_properties()
+    )
+    percent_postcodes_by_gas = str(process_data.get_total_on_off_gas_postcodes())
 
     with open(os.path.join(output_folder, "stats.txt"), "w") as stats_txt:
         stats_txt.writelines(
@@ -231,8 +253,38 @@ if __name__ == "__main__":
                 epc_c_wall_proportion,
                 epc_c_wall_roof,
                 epc_c_wall_roof_proportion,
+                installations_by_rurality,
+                installations_by_gas_status,
+                "Percent of properties in Wales by rurality:\n",
+                percent_properties_by_rurality,
+                "\n\nPercent of postcodes in Wales by gas status:\n",
+                percent_postcodes_by_gas,
             ]
         )
+
+    # To recreate October 2023 analysis
+    if get_data.get_args().calculate_average_installations:
+        subset_year_a_mean = process_data.mean_installations_per_year(2015, 2021)
+        subset_year_a_median = process_data.median_installations_per_year(2015, 2021)
+        subset_year_a_text = (
+            f"\nMean number of MCS installations in Wales per year from 2016-2020: {subset_year_a_mean}."
+            f"\nMedian number of MCS installations in Wales per year from 2016-2020: {subset_year_a_median}."
+        )
+
+        subset_year_b_mean = process_data.mean_installations_per_year(2020, 2023)
+        subset_year_b_text = f"\nMean number of MCS installations in Wales per year from 2021-2022: {subset_year_b_mean}."
+
+        installations_df = process_data.get_installations_per_year()
+        installations_2023 = installations_df[installations_df["year"] == 2023]["n"]
+
+        with open(os.path.join(output_folder, "stats.txt"), "w") as stats_txt:
+            stats_txt.writelines(
+                [
+                    subset_year_a_text,
+                    subset_year_b_text,
+                    f"Total installations in 2023: {installations_2023}",
+                ]
+            )
 
     # Tenure of Welsh HPs
     proportions_bar_chart(

--- a/asf_welsh_energy_consultation/analysis/produce_plots_and_stats.py
+++ b/asf_welsh_energy_consultation/analysis/produce_plots_and_stats.py
@@ -267,7 +267,7 @@ if __name__ == "__main__":
         subset_year_a_mean = process_data.mean_installations_per_year(2015, 2021)
         subset_year_a_median = process_data.median_installations_per_year(2015, 2021)
         subset_year_a_text = (
-            f"\nMean number of MCS installations in Wales per year from 2016-2020: {subset_year_a_mean}."
+            f"\n\nMean number of MCS installations in Wales per year from 2016-2020: {subset_year_a_mean}."
             f"\nMedian number of MCS installations in Wales per year from 2016-2020: {subset_year_a_median}."
         )
 
@@ -275,14 +275,17 @@ if __name__ == "__main__":
         subset_year_b_text = f"\nMean number of MCS installations in Wales per year from 2021-2022: {subset_year_b_mean}."
 
         installations_df = process_data.get_installations_per_year()
-        installations_2023 = installations_df[installations_df["year"] == 2023]["n"]
+        # Get single value for installations in 2023
+        installations_2023 = installations_df[installations_df["year"] == 2023][
+            "n"
+        ].values[0]
 
-        with open(os.path.join(output_folder, "stats.txt"), "w") as stats_txt:
+        with open(os.path.join(output_folder, "stats.txt"), "a") as stats_txt:
             stats_txt.writelines(
                 [
                     subset_year_a_text,
                     subset_year_b_text,
-                    f"Total installations in 2023: {installations_2023}",
+                    f"\nTotal installations in 2023: {installations_2023}",
                 ]
             )
 

--- a/asf_welsh_energy_consultation/config/base.yaml
+++ b/asf_welsh_energy_consultation/config/base.yaml
@@ -8,3 +8,4 @@ supplementary_data:
   postcode_to_oa_data: "postcode_to_output_area.csv"
   rurality_data: "rurality.ods"
   tenure_data: "tenure.csv"
+  dwelling_data: "dwellings_2021.xlsx"

--- a/asf_welsh_energy_consultation/getters/get_data.py
+++ b/asf_welsh_energy_consultation/getters/get_data.py
@@ -59,9 +59,16 @@ def create_argparser():
     parser.add_argument(
         "--mcs_batch",
         help="Specifies which MCS installations data batch to use. Only date required in YYMMDD format. "
-        'Defaults to "newest"',
+        "Defaults to 'newest'",
         default="newest",
         type=str,
+    )
+
+    parser.add_argument(
+        "--calculate_average_installations",
+        help="Calculate additional high level statistics specific for October 2023 analysis. Defaults to 'False'",
+        default=False,
+        type=bool,
     )
 
     return parser
@@ -103,7 +110,7 @@ def get_mcs_and_joined_data(epc_version):
     installation or earliest after installation, up to date specified in args.
 
     Returns:
-        pd.DataFrame of specified MCS or MCS-EPC joined dataset.
+        pandas.DataFrame: specified MCS or MCS-EPC joined dataset.
     """
     mcs_date = arguments.mcs_batch
 
@@ -208,6 +215,91 @@ def get_mcs_domestic():
     return mcs_domestic
 
 
+def get_rurality():
+    """
+    Get rurality df with country code column.
+
+    Returns:
+        pandas.DataFrame: Rurality data.
+    """
+    rural_path = os.path.join(
+        input_data_path, config_file["supplementary_data"]["rurality_data"]
+    )
+
+    rural_df = pd.read_excel(
+        os.path.join(PROJECT_DIR, rural_path),
+        engine="odf",
+        sheet_name="LSOA11",
+        skiprows=2,
+    )
+
+    rural_df = rural_df.rename(
+        columns={
+            "Lower Super Output Area 2011 Code": "lsoa_code",
+            "Rural Urban Classification 2011 (2 fold)": "rural_2",
+        }
+    )
+
+    # Add country col
+    rural_df["country"] = rural_df["lsoa_code"].apply(lambda x: x[0])
+
+    return rural_df
+
+
+def get_dwelling_data():
+    """
+    Get total number of dwellings per LSOA.
+
+    Returns:
+        pandas.DataFrame: Total number of dwellings per LSOA.
+    """
+    dwelling_path = os.path.join(
+        input_data_path, config_file["supplementary_data"]["dwelling_data"]
+    )
+
+    dwellings = pd.read_excel(
+        os.path.join(PROJECT_DIR, dwelling_path), sheet_name="1c", skiprows=3
+    )
+    dwellings = dwellings[
+        [
+            "LSOA Code",
+            "Total: All dwellings (excluding communal establishments)",
+            "LSOA Name",
+        ]
+    ]
+    dwellings = dwellings.rename(
+        columns={
+            "LSOA Code": "lsoa_code",
+            "Total: All dwellings (excluding communal establishments)": "total_dwellings",
+            "LSOA Name": "lsoa_name",
+        }
+    )
+
+    return dwellings
+
+
+def get_postcode_to_oa():
+    """
+    Get postcode to LSOA df.
+
+    Returns:
+        pandas.DataFrame: Postcode to LSOA.
+    """
+    oa_path = os.path.join(
+        input_data_path, config_file["supplementary_data"]["postcode_to_oa_data"]
+    )
+    oa = pd.read_csv(
+        PROJECT_DIR / oa_path, encoding="latin-1"
+    )  # latin-1 as otherwise invalid byte
+
+    oa = oa[["pcd7", "lsoa11cd"]].rename(
+        columns={"pcd7": "postcode", "lsoa11cd": "lsoa_code"}
+    )
+    oa["postcode"] = oa["postcode"].str.replace(" ", "")
+
+    return oa
+
+
 def get_offgas():
     """Get dataset of off-gas-grid postcodes.
 
@@ -229,7 +321,7 @@ def get_offgas():
     return og
 
 
-def get_rurality():
+def get_rurality_by_oa():
     """Get dataset of postcodes and their rurality indices.
     Two codes are used - the more specific 10-fold code, and the less specific
     two-fold code ("rural"/"urban").

--- a/asf_welsh_energy_consultation/getters/get_data.py
+++ b/asf_welsh_energy_consultation/getters/get_data.py
@@ -278,28 +278,6 @@ def get_dwelling_data():
     return dwellings
 
 
-def get_postcode_to_oa():
-    """
-    Get postcode to LSOA df.
-
-    Returns:
-        pandas.DataFrame: Postcode to LSOA.
-    """
-    oa_path = os.path.join(
-        input_data_path, config_file["supplementary_data"]["postcode_to_oa_data"]
-    )
-    oa = pd.read_csv(
-        PROJECT_DIR / oa_path, encoding="latin-1"
-    )  # latin-1 as otherwise invalid byte
-
-    oa = oa[["pcd7", "lsoa11cd"]].rename(
-        columns={"pcd7": "postcode", "lsoa11cd": "lsoa_code"}
-    )
-    oa["postcode"] = oa["postcode"].str.replace(" ", "")
-
-    return oa
-
-
 def get_offgas():
     """Get dataset of off-gas-grid postcodes.
 

--- a/asf_welsh_energy_consultation/pipeline/process_data.py
+++ b/asf_welsh_energy_consultation/pipeline/process_data.py
@@ -478,13 +478,18 @@ def get_total_on_off_gas_postcodes():
     oa = get_data.get_postcode_to_oa()
 
     postcodes_og = oa.merge(og, how="left", on="postcode")
+
+    # LSOA code used to get country code and filter for Wales
     postcodes_og["country"] = postcodes_og["lsoa_code"].apply(lambda x: str(x)[0])
     wales_og = postcodes_og[postcodes_og["country"] == "W"]
 
+    # Any postcodes not in off gas dataset have NA values in 'off_gas' col
+    # We assume the remaining postcodes are on gas and fillna with 'on gas'
     wales_og["off_gas"] = (
         wales_og["off_gas"].fillna("On gas").replace({True: "Off gas"})
     )
 
+    # Calculate % of postcodes on and off gas
     wales_og_dict = wales_og["off_gas"].value_counts(dropna=False).to_dict()
     wales_postcodes_og_pct_dict = {
         "Off gas": (

--- a/asf_welsh_energy_consultation/pipeline/process_data.py
+++ b/asf_welsh_energy_consultation/pipeline/process_data.py
@@ -22,7 +22,7 @@ def get_enhanced_mcs():
     mcs = get_data.get_mcs_domestic()
     og = get_data.get_offgas()
     countries = get_data.get_countries()
-    rural = get_data.get_rurality()
+    rural = get_data.get_rurality_by_oa()
 
     # join with off-gas data
     mcs = mcs.merge(og, on="postcode", how="left")
@@ -384,3 +384,119 @@ def generate_age_data(wales_df):
     age_data["cumul_prop"] = age_data["percentage"].cumsum()
 
     return age_data
+
+
+def get_installations_per_year():
+    """
+    Get MCS installations per year for Wales.
+    Returns:
+        pandas.DataFrame of MCS installations per year in Wales.
+
+    """
+    mcs = get_enhanced_mcs()
+    mcs["n"] = 1
+    mcs["year"] = pd.to_datetime(mcs["commission_date"]).dt.year
+    installations_by_year = mcs.groupby("year")["n"].sum().reset_index()
+
+    # Sort by date ascending
+    installations_by_year = installations_by_year.sort_values("year")
+    installations_by_year = installations_by_year.rename(
+        columns={"commission_date": "date"}
+    )
+
+    return installations_by_year
+
+
+def mean_installations_per_year(min_year, max_year):
+    """
+    Get mean average MCS installations in Wales per year for given date range.
+    Args:
+        min_year: Minimum year (exclusive)
+        max_year: Maximum year (exclusive)
+
+    Returns:
+        int: Mean average MCS installations per year.
+    """
+    installations_by_year = get_installations_per_year()
+    subset = installations_by_year[
+        (installations_by_year["year"] > min_year)
+        & (installations_by_year["year"] < max_year)
+    ]
+
+    return subset["n"].mean()
+
+
+def median_installations_per_year(min_year, max_year):
+    """
+    Get median average MCS installations in Wales per year for given date range.
+    Args:
+        min_year: Minimum year (exclusive)
+        max_year: Maximum year (exclusive)
+
+    Returns:
+        int: Median average MCS installations per year.
+    """
+    installations_by_year = get_installations_per_year()
+    subset = installations_by_year[
+        (installations_by_year["year"] > min_year)
+        & (installations_by_year["year"] < max_year)
+    ]
+
+    return subset["n"].median()
+
+
+def get_total_rural_and_urban_properties():
+    """
+    Get total count of properties in Wales in urban vs rural locations.
+
+    Returns:
+        dict: Percent of rural and urban properties in Wales.
+    """
+    rural = get_data.get_rurality()
+    dwellings = get_data.get_dwelling_data()
+
+    df = dwellings.merge(rural, how="left", on="lsoa_code")
+    df = df[df["country"] == "W"]
+    rurality = df.groupby("rural_2")["total_dwellings"].sum().to_dict()
+    rurality_pct_dict = {
+        "Rural": (rurality["Rural"] / (rurality["Rural"] + rurality["Urban"])) * 100,
+        "Urban": (rurality["Urban"] / (rurality["Rural"] + rurality["Urban"])) * 100,
+    }
+
+    return rurality_pct_dict
+
+
+def get_total_on_off_gas_postcodes():
+    """
+    Get total count of postcodes in Wales which are on- vs off-gas.
+
+    Returns:
+        dict: Percent of on- and off-gas postcodes in Wales.
+    """
+
+    og = get_data.get_offgas()
+    oa = get_data.get_postcode_to_oa()
+
+    postcodes_og = oa.merge(og, how="left", on="postcode")
+    postcodes_og["country"] = postcodes_og["lsoa_code"].apply(lambda x: str(x)[0])
+    wales_og = postcodes_og[postcodes_og["country"] == "W"]
+
+    wales_og["off_gas"] = (
+        wales_og["off_gas"].fillna("On gas").replace({True: "Off gas"})
+    )
+
+    wales_og_dict = wales_og["off_gas"].value_counts(dropna=False).to_dict()
+    wales_postcodes_og_pct_dict = {
+        "Off gas": (
+            wales_og_dict["Off gas"]
+            / (wales_og_dict["Off gas"] + wales_og_dict["On gas"])
+        )
+        * 100,
+        "On gas": (
+            wales_og_dict["On gas"]
+            / (wales_og_dict["Off gas"] + wales_og_dict["On gas"])
+        )
+        * 100,
+    }
+
+    return wales_postcodes_og_pct_dict

--- a/asf_welsh_energy_consultation/pipeline/process_data.py
+++ b/asf_welsh_energy_consultation/pipeline/process_data.py
@@ -475,19 +475,17 @@ def get_total_on_off_gas_postcodes():
     """
 
     og = get_data.get_offgas()
-    oa = get_data.get_postcode_to_oa()
+    postcodes = get_data.get_countries()
 
-    postcodes_og = oa.merge(og, how="left", on="postcode")
-
-    # LSOA code used to get country code and filter for Wales
-    postcodes_og["country"] = postcodes_og["lsoa_code"].apply(lambda x: str(x)[0])
-    wales_og = postcodes_og[postcodes_og["country"] == "W"]
+    postcodes_og = postcodes.merge(og, how="left", on="postcode")
 
     # Any postcodes not in off gas dataset have NA values in 'off_gas' col
     # We assume the remaining postcodes are on gas and fillna with 'on gas'
-    wales_og["off_gas"] = (
-        wales_og["off_gas"].fillna("On gas").replace({True: "Off gas"})
-    )
+    postcodes_og["off_gas"] = postcodes_og["off_gas"].replace({True: "Off gas"})
+    postcodes_og["off_gas"] = postcodes_og["off_gas"].fillna("On gas")
+
+    # Filter for Wales only
+    wales_og = postcodes_og.loc[postcodes_og["country"] == "Wales"].copy()
 
     # Calculate % of postcodes on and off gas
     wales_og_dict = wales_og["off_gas"].value_counts(dropna=False).to_dict()


### PR DESCRIPTION
Fixes #12 

# Description

New stats added:

1. % of MCS installations by rurality and gas status
2. % of dwellings in Wales by rurality
3. % of postcodes in Wales by gas status
4. installations per year - mean and median for specified year ranges for October 2023 analysis

Related to point 4 above - I added a new arg to pass when running the script specifically to recreate numbers for the October 2023 analysis related to installations per year for specific year ranges. Not ideal to hard code this, but I wrote it this way due to time limitations and for posterity in the code so that someone can recreate the October 2023 stats later if they need to.

# Instructions for Reviewer

- This code requires new supplementary data from S3 so you will need to run `make inputs-pull` again.
- Please could you check that the calculations are correct to calculate the new stats, especially the `get_total_rural_and_urban_properties` and `get_total_on_off_gas_postcodes` functions in `process_data.py`
- Please could you pay special attention to the df merges in the new `get_total_on_off_gas_postcodes` function. The off gas dataset contains a list of postcodes that are off gas. For the analysis, we therefore make the assumption that postcodes not included in the off gas dataset are on gas and therefore after joining with postcode data, we fillna postcodes with 'on gas' label. Please could you double check this logic is what's happening in the code on the merge.

# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [x] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
