### PR TITLE
11 fix cumulative retrofits

### DIFF
--- a/asf_welsh_energy_consultation/analysis/produce_plots_and_stats.py
+++ b/asf_welsh_energy_consultation/analysis/produce_plots_and_stats.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
     logger.info(f"Saved: {os.path.join(output_folder, 'new_build_hp_proportion.html')}")
 
     # ======================================================
-    # Cumulative number of new builds with heat pumps
+    # Cumulative number of new builds with heat pumps - note: uses EPC data only
 
     new_build_hp_cumulative = process_data.get_new_builds_hp_cumsums()
 
@@ -113,7 +113,7 @@ if __name__ == "__main__":
         alt.Chart(
             new_build_hp_cumulative,
             title=[
-                "Cumulative heat pump installations in new builds with EPC registrations in Wales since 2008",
+                "Cumulative heat pump installations in new builds in Wales since 2008",
             ],
         )
         .mark_line()
@@ -236,7 +236,7 @@ if __name__ == "__main__":
             ]
         )
 
-    # Tenure of Welsh HPs
+    # Tenure of Welsh HPs - uses EPC data only
     proportions_bar_chart(
         wales_hp,
         "TENURE",
@@ -257,7 +257,7 @@ if __name__ == "__main__":
     proportions_bar_chart(
         wales_df.loc[wales_df.CURRENT_ENERGY_RATING != "unknown"],
         "CURRENT_ENERGY_RATING",
-        "EPC ratings of all Welsh EPC-registered properties",
+        "EPC ratings of all EPC-registered Welsh properties",
         "Energy efficiency rating",
         "Percentage of properties",
         filename="epc_all",

--- a/asf_welsh_energy_consultation/analysis/produce_plots_and_stats.py
+++ b/asf_welsh_energy_consultation/analysis/produce_plots_and_stats.py
@@ -113,8 +113,7 @@ if __name__ == "__main__":
         alt.Chart(
             new_build_hp_cumulative,
             title=[
-                "Cumulative total of EPC registrations for new builds",
-                "with heat pumps in Wales since 2008",
+                "Cumulative heat pump installations in new builds with EPC registrations in Wales since 2008",
             ],
         )
         .mark_line()
@@ -122,6 +121,7 @@ if __name__ == "__main__":
             x="Date",
             y="Number of EPCs",
         )
+        .configure_line(color="#0000ff")
         .properties(width=600, height=300)
     )
 
@@ -153,6 +153,7 @@ if __name__ == "__main__":
             ),
             y="Number of heat pumps",
         )
+        .configure_line(color="#0000ff")
         .properties(width=600, height=300)
     )
 
@@ -178,6 +179,7 @@ if __name__ == "__main__":
             y=alt.Y("n", title="Number of properties"),
         )
         .configure(lineBreak="\n")
+        .configure_bar(color="#0000ff")
         .properties(width=600, height=300)
     ).configure_title(fontSize=20)
 
@@ -238,7 +240,7 @@ if __name__ == "__main__":
     proportions_bar_chart(
         wales_hp,
         "TENURE",
-        "Tenure of Welsh properties with heat pumps",
+        "Tenure of Welsh EPC-registered properties with heat pumps",
         "Tenure",
         "Percentage of properties",
         filename="hp_tenure",
@@ -255,7 +257,7 @@ if __name__ == "__main__":
     proportions_bar_chart(
         wales_df.loc[wales_df.CURRENT_ENERGY_RATING != "unknown"],
         "CURRENT_ENERGY_RATING",
-        "EPC ratings of all Welsh properties",
+        "EPC ratings of all Welsh EPC-registered properties",
         "Energy efficiency rating",
         "Percentage of properties",
         filename="epc_all",
@@ -268,7 +270,7 @@ if __name__ == "__main__":
         "CURRENT_ENERGY_RATING",
         [
             "EPC ratings of owner-occupied and privately rented",
-            "Welsh properties with heat pumps",
+            "Welsh EPC-registered properties with heat pumps",
         ],
         "Energy efficiency rating",
         "Percentage of properties",

--- a/asf_welsh_energy_consultation/pipeline/process_data.py
+++ b/asf_welsh_energy_consultation/pipeline/process_data.py
@@ -111,8 +111,6 @@ def cumsums_by_variable(variable, new_var_name, data=enhanced_mcs):
 
 # PROCESSING EPC
 
-wales_epc = get_data.get_wales_processed_epc()
-
 
 def correct_new_dwelling_labels():
     """
@@ -122,6 +120,7 @@ def correct_new_dwelling_labels():
     Returns:
         pd.DataFrame: Wales EPC certificates
     """
+    wales_epc = get_data.get_wales_processed_epc()
     wales_epc["rank"] = wales_epc.groupby("UPRN")["INSPECTION_DATE"].rank(
         "dense", na_option="bottom"
     )
@@ -247,6 +246,31 @@ def identify_mcs_with_multiple_epc():
     return duplicate_uprns
 
 
+def add_unique_mcs_id(df):
+    """
+    Add unique id column generated from MCS commission date, address 1, 2 and 3, and postcode columns.
+
+    Args:
+        df: DataFrame to add unique id column to. Df must be derived from MCS data with the appropriate columns.
+
+    Returns:
+        pandas.DataFrame: DataFrame with unique ID column added.
+    """
+    df["unique_id"] = (
+        df["commission_date"].astype(str)
+        + ".."
+        + df["address_1"].astype(str)
+        + ".."
+        + df["address_2"].astype(str)
+        + ".."
+        + df["address_3"].astype(str)
+        + ".."
+        + df["postcode"].astype(str)
+    )
+
+    return df
+
+
 def mcs_epc_first_records():
     """Get first records from fully joined MCS-EPC dataset. Note: all rows with UPRNs associated with multiple MCS installations
     in the dataset are removed to avoid double counting.
@@ -271,8 +295,10 @@ def mcs_epc_first_records():
         )
     mcs_epc = mcs_epc.loc[mcs_epc["country"] == "Wales"].reset_index(drop=True)
 
+    mcs_epc = add_unique_mcs_id(mcs_epc)
+
     first_records = (
-        mcs_epc.sort_values("INSPECTION_DATE").groupby("original_mcs_index").head(1)
+        mcs_epc.sort_values("INSPECTION_DATE").groupby(["unique_id"]).head(1)
     )
 
     return first_records
@@ -315,14 +341,17 @@ def get_mcs_retrofits():
     first_records = add_hp_when_built_column(first_records)
 
     hp_when_built_indices = first_records.loc[first_records["assumed_hp_when_built"]][
-        "original_mcs_index"
+        "unique_id"
     ]
     # note: for properties not joined to EPC, assumed_hp_when_built is False
     # this makes sense because if they had been built with a HP we would expect them to appear in EPC
     # due to new build EPC requirements
 
     enhanced_mcs = get_enhanced_mcs()
-    mcs_retrofits = enhanced_mcs.loc[~enhanced_mcs.index.isin(hp_when_built_indices)]
+    enhanced_mcs = add_unique_mcs_id(enhanced_mcs)
+    mcs_retrofits = enhanced_mcs.loc[
+        ~enhanced_mcs["unique_id"].isin(hp_when_built_indices)
+    ]
 
     return mcs_retrofits
 

--- a/asf_welsh_energy_consultation/pipeline/process_data.py
+++ b/asf_welsh_energy_consultation/pipeline/process_data.py
@@ -44,7 +44,7 @@ def get_enhanced_mcs():
     mcs = mcs.merge(rural, on="postcode", how="left")
     if mcs.rurality_10_code.isna().sum() > 0:
         logger.warning(
-            f"Loss of data: {mcs.rurality_10_code.isna().sum()} Welsh MCS installation records have no rurality code match."
+            f"Loss of data when using rurality variable: {mcs.rurality_10_code.isna().sum()} Welsh MCS installation records have no rurality code match."
         )
 
     # add custom rurality column (rurality "type 7": all different types of urban mapped to Urban)


### PR DESCRIPTION
Fixes #11 

# Changes

- Fix bug in cumulative_retrofits calculations by replacing use of `original_mcs_index` with newly generated `unique_id` created from MCS commission date, address columns, and postcode.
- Update all graphs to be Nesta blue
- Update titles of graphs to more clearly indicate source of data

# Instructions for Reviewer

- Please could you review the generation of the new `unique_id` column and flag any potential issues with it.
- Please let me know your opinion on the new methodology and if the numbers seem reasonable.
- Please review updated titles of graphs.

# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
